### PR TITLE
Update to AudioGeneratorMOD.cpp to fix DIVIDER pb

### DIFF
--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -17,8 +17,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#define PGM_READ_UNALIGNED 0
 
+#define PGM_READ_UNALIGNED 0
 #include "AudioGeneratorMOD.h"
 
 /* 


### PR DESCRIPTION
Replaced DIVIDER with MOD_DIVIDER to avoid naming conflicts (same modification needs to be done on AudioGeneratorMOD.h for the fix to work).